### PR TITLE
fix(overrides): allows explicitly undefined values in all overrides to take precedence over non-undefined values in the recipe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,13 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "deepmerge": "^4.3.1",
+        "@types/lodash.mergewith": "^4.6.9",
         "immer": "^10.1.1",
-        "lodash.merge": "^4.6.2",
-        "uuid": "^11.1.0"
+        "lodash.mergewith": "^4.6.2"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.9.0",
         "@types/jest": "^30.0.0",
-        "@types/lodash.merge": "^4.6.9",
         "jest": "^30.0.5",
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.0",
@@ -534,34 +532,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
@@ -1826,42 +1796,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -1967,14 +1901,12 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
-      "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash.merge": {
+    "node_modules/@types/lodash.mergewith": {
       "version": "4.6.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
-      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
+      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -2303,21 +2235,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2383,15 +2300,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -2884,15 +2792,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2945,6 +2844,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2958,18 +2858,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -4312,10 +4200,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.merge": {
+    "node_modules/lodash.mergewith": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {
@@ -5583,52 +5471,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5834,28 +5676,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -6129,18 +5949,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
+    "@types/lodash.mergewith": "^4.6.9",
     "immer": "^10.1.1",
-    "lodash.merge": "^4.6.2"
+    "lodash.mergewith": "^4.6.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.9.0",
     "@types/jest": "^30.0.0",
-    "@types/lodash.merge": "^4.6.9",
     "jest": "^30.0.5",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.0",

--- a/src/core/internal/fixture-draft/fixture-draft-factory.ts
+++ b/src/core/internal/fixture-draft/fixture-draft-factory.ts
@@ -1,9 +1,9 @@
-import merge from "lodash.merge";
 import { DraftOptions } from "types/internal";
 import { ContextImpl } from "../context";
 import { FactoryContext } from "../fixture-factory";
 import { FixtureRecipeImpl } from "../fixture-recipe";
 import { FixtureDraft } from "./fixture-draft";
+import { forceMerge } from "utils/internal";
 
 /**
  * Factory for creating draft fixtures.
@@ -26,15 +26,15 @@ export class FixtureDraftFactory {
 
     // Must start tracking the current drafting session to ensure that lazy values are only resolved when building the main fixture, not nested ones
     factoryCtx.depthTracker.startDraftingMode();
-    
-    let draft = merge(recipe.createDraft(ctx), recipe.override);
+
+    let draft = forceMerge(recipe.createDraft(ctx), recipe.override);
 
     for (const variant of options.variants ?? []) {
-      draft = merge(draft, variant.override);
+      draft = forceMerge(draft, variant.override);
     }
 
     if (options.overrideDraft) {
-      draft = merge(draft, options.overrideDraft(ctx));
+      draft = forceMerge(draft, options.overrideDraft(ctx));
     }
 
     ctx.draft = draft as TFixture;

--- a/src/core/internal/fixture-recipe.ts
+++ b/src/core/internal/fixture-recipe.ts
@@ -1,7 +1,7 @@
-import merge from "lodash.merge";
 import { FixtureFactoryImpl } from "./fixture-factory/fixture-factory";
 import { RecipeFunction, Override } from "types/internal";
 import { FixtureRecipe, FixtureFactory } from "types";
+import { forceMerge } from "utils/internal";
 
 export class FixtureRecipeImpl<TFixture> implements FixtureRecipe<TFixture> {
   constructor(
@@ -10,7 +10,7 @@ export class FixtureRecipeImpl<TFixture> implements FixtureRecipe<TFixture> {
   ) {}
 
   variant(override: Override<TFixture>): FixtureRecipe<TFixture> {
-    return new FixtureRecipeImpl(this.createDraft, merge(this.override, override));
+    return new FixtureRecipeImpl(this.createDraft, forceMerge(this.override, override));
   }
 
   createFactory(): FixtureFactory<TFixture> {

--- a/src/utils/internal/configuration.ts
+++ b/src/utils/internal/configuration.ts
@@ -1,4 +1,4 @@
-import merge from "lodash.merge";
+import mergewith from "lodash.mergewith";
 import { produce } from "immer";
 import { Config } from "types/internal";
 import { Override } from "types/internal";
@@ -14,7 +14,7 @@ let _config: Config = DEFAULT_CONFIG;
 
 export function setConfig(config: Override<Config>): void {
   _config = produce(_config, (draft) => {
-    merge(draft, config);
+    mergewith(draft, config);
   });
 }
 

--- a/src/utils/internal/force-merge.ts
+++ b/src/utils/internal/force-merge.ts
@@ -1,0 +1,19 @@
+import mergeWith from "lodash.mergewith";
+
+/**
+ * Deep merges two objects, forcing the values of the other object to override those of the source object.
+ * Values explicitly marked as undefined in the other object will take precedence over values from the source object.
+ * 
+ * @param {Object} src The source object.
+ * @param {Object} other The other object.
+ * @
+ */
+export function forceMerge<T, S>(src: T, other: S) {
+  return mergeWith(src, other, customizer);
+}
+
+function customizer(objValue: any, srcValue: any, key: string, obj: any) {
+  if (objValue !== srcValue && typeof srcValue === "undefined") {
+    obj[key] = srcValue;
+  }
+}

--- a/src/utils/internal/index.ts
+++ b/src/utils/internal/index.ts
@@ -1,5 +1,6 @@
 export * from './configuration';
 export * from './contextual';
 export * from './enumerate';
+export * from './force-merge';
 export * from './get-number-between';
 export * from './lazy';

--- a/tests/core/internal/fixture-draft/fixture-draft-factory.test.ts
+++ b/tests/core/internal/fixture-draft/fixture-draft-factory.test.ts
@@ -17,11 +17,7 @@ describe(FixtureDraftFactory.name, () => {
   describe(FixtureDraftFactory.prototype.create.name, () => {
     describe("Is base draft", () => {
       it("should return a draft marked as being a base draft", () => {
-        const result = instance.create(
-          ctx,
-          new FixtureRecipeImpl(() => ({ prop1: 10, prop2: "foo", array: [1, 2, 3, 4] })),
-          {},
-        );
+        const result = instance.create(ctx, new FixtureRecipeImpl(() => ({ prop1: 10, prop2: "foo", array: [1, 2, 3, 4] })), {});
 
         expect(result.isBaseDraft).toBe(true);
         expect(result.draft).toEqual({ prop1: 10, prop2: "foo", array: [1, 2, 3, 4] });
@@ -31,11 +27,7 @@ describe(FixtureDraftFactory.name, () => {
     describe("Is not base draft", () => {
       it("should return a draft marked as not a base draft", () => {
         ctx.depthTracker.startDraftingMode();
-        const result = instance.create(
-          ctx,
-          new FixtureRecipeImpl(() => ({ prop1: 10, prop2: "foo", array: [1, 2, 3, 4] })),
-          {},
-        );
+        const result = instance.create(ctx, new FixtureRecipeImpl(() => ({ prop1: 10, prop2: "foo", array: [1, 2, 3, 4] })), {});
         ctx.depthTracker.exitDraftingMode();
 
         expect(result.isBaseDraft).toBe(false);
@@ -56,11 +48,35 @@ describe(FixtureDraftFactory.name, () => {
     describe("Recipe is a variant", () => {
       it("should return the draft created from the recipe", () => {
         const buildFunction = jest.fn().mockReturnValue({ prop1: "Recipe - Will be overridden", prop2: "Recipe" });
-        const recipe = new FixtureRecipeImpl(buildFunction, { prop1: "Variant" });
+        const recipe = new FixtureRecipeImpl(buildFunction);
+        const variant = recipe.variant({ prop1: "Variant" }) as FixtureRecipeImpl<any>;
 
-        const result = instance.create(ctx, recipe, {});
+        const result = instance.create(ctx, variant, {});
 
         expect(result.draft).toEqual({ prop1: "Variant", prop2: "Recipe" });
+      });
+
+      it("should let the variant's undefined values override non-undefined source values", () => {
+        const buildFunction = jest.fn().mockReturnValue({ prop1: "Recipe - Will be overridden", prop2: "Recipe" });
+        const recipe = new FixtureRecipeImpl(buildFunction);
+        const variant = recipe.variant({ prop1: undefined }) as FixtureRecipeImpl<any>;
+
+        const result = instance.create(ctx, variant, {});
+
+        expect(result.draft).toEqual({ prop1: undefined, prop2: "Recipe" });
+      });
+    });
+
+    describe("Recipe is a variant of another variant", () => {
+      it("should let the variant's undefined values override non-undefined source values", () => {
+        const buildFunction = jest.fn().mockReturnValue({ prop1: "Recipe", prop2: "Recipe - Will be overriden" });
+        const recipe = new FixtureRecipeImpl(buildFunction);
+        const variant1 = recipe.variant({ prop2: "Variant 1 - Will be overriden" });
+        const variant2 = variant1.variant({ prop2: undefined }) as FixtureRecipeImpl<any>;
+
+        const result = instance.create(ctx, variant2, {});
+
+        expect(result.draft).toEqual({ prop1: "Recipe", prop2: undefined });
       });
     });
 
@@ -73,6 +89,16 @@ describe(FixtureDraftFactory.name, () => {
         const result = instance.create(ctx, recipe, createOptions([variant]));
 
         expect(result.draft).toEqual({ prop1: "Overriden by variant", prop2: "Recipe" });
+      });
+
+      it("should let the variant's undefined values override non-undefined source values", () => {
+        const buildFunction = jest.fn().mockReturnValue({ prop1: "Recipe - Will be overridden", prop2: "Recipe" });
+        const recipe = new FixtureRecipeImpl(buildFunction);
+        const variant = new FixtureRecipeImpl(jest.fn(), { prop1: undefined });
+
+        const result = instance.create(ctx, recipe, createOptions([variant]));
+
+        expect(result.draft).toEqual({ prop1: undefined, prop2: "Recipe" });
       });
     });
 
@@ -101,6 +127,19 @@ describe(FixtureDraftFactory.name, () => {
         );
 
         expect(result.draft).toEqual({ prop1: "Recipe", prop2: "Overridden" });
+      });
+
+      it("should let the override's undefined values override non-undefined source values", () => {
+        const buildFunction = jest.fn().mockReturnValue({ prop1: "Recipe", prop2: "Recipe - Will be overridden" });
+        const recipe = new FixtureRecipeImpl(buildFunction);
+
+        const result = instance.create(
+          ctx,
+          recipe,
+          createOptions([], () => ({ prop2: undefined })),
+        );
+
+        expect(result.draft).toEqual({ prop1: "Recipe", prop2: undefined });
       });
     });
 

--- a/tests/core/internal/fixture-recipe.test.ts
+++ b/tests/core/internal/fixture-recipe.test.ts
@@ -16,6 +16,16 @@ describe(FixtureRecipeImpl.name, () => {
       expect(result.createDraft).toBe(instance.createDraft);
       expect(result.override).toEqual({ name: "bar" });
     });
+
+    it("should let properties explicitly set as undefined in the override 'erase' the base properties", () => {
+      const instance = new FixtureRecipeImpl<Foo>(() => ({ id: 10, name: "foo" }));
+      const result = instance.variant({ name: undefined }) as FixtureRecipeImpl<Foo>;
+
+      expect(result).toBeTruthy();
+      expect(result).not.toBe(instance);
+      expect(result.createDraft).toBe(instance.createDraft);
+      expect(result.override).toEqual({ name: undefined });
+    });
   });
 
   describe(FixtureRecipeImpl.prototype.createFactory.name, () => {

--- a/tests/utils/internal/force-merge.test.ts
+++ b/tests/utils/internal/force-merge.test.ts
@@ -1,0 +1,43 @@
+import { forceMerge } from "utils/internal";
+
+describe(forceMerge.name, () => {
+  describe("same properties in both objects", () => {
+    it("should return the equivalent of the other object", () => {
+      const obj = { a: 1, b: 2 };
+      const other = { a: 3, b: 4 };
+
+      const result = forceMerge(obj, other);
+      expect(result).toEqual({ a: 3, b: 4 });
+    });
+  });
+
+  describe("unset property in src object", () => {
+    it("should let the property from the other object win", () => {
+      const obj = { a: 1 };
+      const other = { a: 3, b: 4 };
+
+      const result = forceMerge(obj, other);
+      expect(result).toEqual({ a: 3, b: 4 });
+    });
+  });
+
+  describe("unset property in other object", () => {
+    it("should let the property from the source object win", () => {
+      const obj = { a: 1, b: 2 };
+      const other = { a: 3 };
+
+      const result = forceMerge(obj, other);
+      expect(result).toEqual({ a: 3, b: 2 });
+    });
+  });
+
+  describe("property from the other object set to undefined", () => {
+    it("should lead to an undefined property in the resulting object", () => {
+      const obj = { a: 1, b: 2 };
+      const other = { a: 3, b: undefined };
+
+      const result = forceMerge(obj, other);
+      expect(result).toEqual({ a: 3, b: undefined });
+    });
+  });
+});


### PR DESCRIPTION
When specifying an override, whether via a variant or when creating a fixture, explicitly defining a property as undefined will correctly override the value set in the recipe.